### PR TITLE
feat: Add weekly news summary feature

### DIFF
--- a/__tests__/lib/helpers.test.js
+++ b/__tests__/lib/helpers.test.js
@@ -1,0 +1,110 @@
+// __tests__/lib/helpers.test.js
+// Assume this file might already exist and have other tests.
+// We're adding tests for getNewsSummaries.
+
+import { getNewsSummaries } from '../../lib/helpers'; // Adjust path
+import { normalizeEvent } from '../../utils/normalize'; // Adjust path
+import * as Sentry from '@sentry/nextjs';
+
+// Mock fetch globally
+global.fetch = jest.fn();
+
+// Mock Sentry
+jest.mock('@sentry/nextjs', () => ({
+  captureException: jest.fn(),
+  captureMessage: jest.fn(),
+}));
+
+
+// Mock normalizeEvent as its implementation is not part of this specific unit test
+jest.mock('../../utils/normalize', () => ({
+  normalizeEvent: jest.fn(item => ({ ...item, normalized: true })),
+}));
+
+describe('getNewsSummaries', () => {
+  beforeEach(() => {
+    fetch.mockClear();
+    normalizeEvent.mockClear();
+    Sentry.captureException.mockClear();
+    Sentry.captureMessage.mockClear();
+    // Set up default environment variables that might be needed by the function
+    process.env.NEXT_PUBLIC_NEWS_CALENDAR_ID = 'test_news_calendar_id';
+    process.env.NEXT_PUBLIC_GOOGLE_CALENDAR = 'test_api_key';
+  });
+
+  it('should fetch and normalize news summaries correctly', async () => {
+    const mockCalendarItems = [{ id: '1', summary: 'Raw News 1' }];
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: mockCalendarItems }),
+    });
+
+    const result = await getNewsSummaries({ maxResults: 1 });
+
+    expect(fetch).toHaveBeenCalledTimes(1);
+    const expectedUrl = `https://www.googleapis.com/calendar/v3/calendars/test_news_calendar_id/events?key=test_api_key&timeMin=${expect.any(String)}&singleEvents=true&orderBy=startTime&maxResults=1&showDeleted=false`;
+    expect(fetch).toHaveBeenCalledWith(expectedUrl);
+
+    expect(normalizeEvent).toHaveBeenCalledWith(mockCalendarItems[0]);
+    expect(result.newsSummaries).toEqual([{ id: '1', summary: 'Raw News 1', normalized: true }]);
+    expect(result.noEventsFound).toBe(false);
+  });
+
+  it('should return noEventsFound if API returns no items', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    const result = await getNewsSummaries();
+
+    expect(result.newsSummaries).toEqual([]);
+    expect(result.noEventsFound).toBe(true);
+  });
+
+  it('should return noEventsFound if API returns no items property', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({}), // No 'items' property
+    });
+
+    const result = await getNewsSummaries();
+    expect(result.newsSummaries).toEqual([]);
+    expect(result.noEventsFound).toBe(true);
+  });
+
+  it('should handle API fetch error gracefully and capture to Sentry', async () => {
+    fetch.mockResolvedValueOnce({
+      ok: false,
+      statusText: 'Internal Server Error',
+    });
+
+    const result = await getNewsSummaries();
+
+    expect(result.newsSummaries).toEqual([]);
+    expect(result.noEventsFound).toBe(true);
+    expect(Sentry.captureMessage).toHaveBeenCalledWith(expect.stringContaining('Error fetching news summaries: Internal Server Error'));
+  });
+
+  it('should handle exception during fetch and capture to Sentry', async () => {
+    fetch.mockRejectedValueOnce(new Error('Network failure'));
+
+    const result = await getNewsSummaries();
+
+    expect(result.newsSummaries).toEqual([]);
+    expect(result.noEventsFound).toBe(true);
+    expect(Sentry.captureException).toHaveBeenCalledWith(new Error('Network failure'));
+  });
+
+   it('should use default NEWS_CALENDAR_ID if env var is not set', async () => {
+    delete process.env.NEXT_PUBLIC_NEWS_CALENDAR_ID; // Ensure it's not set
+    fetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({ items: [] }),
+    });
+
+    await getNewsSummaries();
+    const expectedUrl = `https://www.googleapis.com/calendar/v3/calendars/YOUR_NEWS_CALENDAR_ID/events?key=test_api_key&timeMin=${expect.any(String)}&singleEvents=true&orderBy=startTime&maxResults=1&showDeleted=false`;
+    expect(fetch).toHaveBeenCalledWith(expectedUrl); // Checks if it uses the fallback ID
+  });
+});

--- a/__tests__/pages/api/news.test.js
+++ b/__tests__/pages/api/news.test.js
@@ -1,0 +1,66 @@
+// __tests__/pages/api/news.test.js
+import { createMocks } from 'node-mocks-http';
+import newsHandler from '../../../pages/api/news'; // Adjust path if needed
+import * as Sentry from '@sentry/nextjs';
+
+// Mock a function from a module
+jest.mock('../../../lib/helpers', () => ({
+  getNewsSummaries: jest.fn(),
+}));
+const { getNewsSummaries } = require('../../../lib/helpers'); // require it after mocking
+
+// Mock Sentry
+jest.mock('@sentry/nextjs', () => ({
+  withSentry: jest.fn((handler) => handler), // Mock withSentry to just return the handler
+}));
+
+
+describe('/api/news', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return news summaries successfully', async () => {
+    const mockNewsData = {
+      newsSummaries: [{ id: '1', summary: 'Test News', description: 'Test content' }],
+      noEventsFound: false,
+    };
+    getNewsSummaries.mockResolvedValue(mockNewsData);
+
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await newsHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual(mockNewsData);
+    expect(res._getHeaders()['cache-control']).toBe('public, s-maxage=3600, stale-while-revalidate=1800');
+  });
+
+  it('should return 200 and empty data if no news summaries are found', async () => {
+    getNewsSummaries.mockResolvedValue({ newsSummaries: [], noEventsFound: true });
+
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await newsHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(200);
+    expect(JSON.parse(res._getData())).toEqual({ newsSummaries: [], noEventsFound: true });
+  });
+
+  it('should return 500 if getNewsSummaries throws an error', async () => {
+    getNewsSummaries.mockRejectedValue(new Error('Failed to fetch'));
+
+    const { req, res } = createMocks({
+      method: 'GET',
+    });
+
+    await newsHandler(req, res);
+
+    expect(res._getStatusCode()).toBe(500);
+    expect(JSON.parse(res._getData())).toEqual({ error: 'Failed to fetch news summaries' });
+  });
+});

--- a/components/hooks/useNewsSummary.js
+++ b/components/hooks/useNewsSummary.js
@@ -1,0 +1,57 @@
+// components/hooks/useNewsSummary.js
+import useSWR, { preload } from 'swr';
+
+const fetcher = async (url) => {
+  const res = await fetch(url);
+
+  if (!res.ok) {
+    const error = new Error('An error occurred while fetching the news data.');
+    // Attach extra info to the error object.
+    try {
+      error.info = await res.json();
+    } catch (e) {
+      // If res.json() fails, use text content
+      error.info = await res.text();
+    }
+    error.status = res.status;
+    throw error;
+  }
+
+  return res.json();
+};
+
+const API_ENDPOINT = '/api/news';
+
+// Call preload for the API endpoint before the hook definition or first use.
+// This helps in starting the fetch early if this module is loaded.
+preload(API_ENDPOINT, fetcher);
+
+export const useNewsSummary = (options = {}) => {
+  const swrOptions = {
+    suspense: options.suspense || false,
+    keepPreviousData: options.keepPreviousData || true,
+    refreshInterval: options.refreshInterval || 60 * 60 * 1000, // Refresh every 1 hour
+    revalidateOnFocus: options.revalidateOnFocus || true,
+    revalidateOnReconnect: options.revalidateOnReconnect || true,
+    // fallbackData: options.fallbackData, // Example: provide initial data
+    ...options, // Allow overriding SWR options from the component
+  };
+
+  const { data, error, isLoading, isValidating } = useSWR(
+    API_ENDPOINT,
+    fetcher,
+    swrOptions
+  );
+
+  return {
+    data, // Expected to be { newsSummaries: [], noEventsFound: boolean }
+    isLoading: isLoading || isValidating, // Combine SWR's loading states
+    error, // Return the error object directly, as expected by NewsPage.js
+  };
+};
+
+// Optional: A specific function to explicitly trigger preloading news summary data
+// This can be useful for scenarios like preloading on link hover, etc.
+export const preloadNewsSummary = () => {
+  return preload(API_ENDPOINT, fetcher);
+};

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -207,3 +207,45 @@ export async function getCalendarEvents({
     noEventsFound: normalizedEvents.length === 0,
   };
 }
+
+export async function getNewsSummaries({ maxResults = 1 } = {}) {
+  // TODO: Replace 'YOUR_NEWS_CALENDAR_ID' with the actual News Calendar ID
+  const NEWS_CALENDAR_ID = process.env.NEXT_PUBLIC_NEWS_CALENDAR_ID || 'YOUR_NEWS_CALENDAR_ID';
+  const API_KEY = process.env.NEXT_PUBLIC_GOOGLE_CALENDAR;
+
+  // Fetch events for the current week or slightly in the past to catch the latest summary
+  const fromDate = new Date();
+  fromDate.setDate(fromDate.getDate() - 7); // Look back 7 days to ensure we catch the latest summary
+  const timeMin = fromDate.toISOString();
+
+  // Construct the API URL
+  // Fetches the most recent 'maxResults' events, ordered by start time
+  const url = `https://www.googleapis.com/calendar/v3/calendars/${NEWS_CALENDAR_ID}/events?key=${API_KEY}&timeMin=${timeMin}&singleEvents=true&orderBy=startTime&maxResults=${maxResults}&showDeleted=false`;
+
+  try {
+    const response = await fetch(url);
+    if (!response.ok) {
+      console.error('Error fetching news summaries:', response.statusText);
+      Sentry.captureMessage(`Error fetching news summaries: ${response.statusText}`);
+      return { newsSummaries: [], noEventsFound: true };
+    }
+
+    const data = await response.json();
+    let normalizedItems = [];
+
+    if (data.items && data.items.length > 0) {
+      // Assuming news summaries are also events that can be normalized
+      // If only one summary is expected, normalizeEvent might be more direct for data.items[0]
+      normalizedItems = data.items.map(item => normalizeEvent(item));
+    }
+
+    return {
+      newsSummaries: normalizedItems,
+      noEventsFound: normalizedItems.length === 0,
+    };
+  } catch (error) {
+    console.error('Exception in getNewsSummaries:', error);
+    Sentry.captureException(error);
+    return { newsSummaries: [], noEventsFound: true };
+  }
+}

--- a/pages/api/news.js
+++ b/pages/api/news.js
@@ -1,0 +1,37 @@
+// pages/api/news.js
+import { withSentry } from "@sentry/nextjs";
+import { getNewsSummaries } from "../../lib/helpers"; // Path to helpers.js
+
+async function handler(req, res) {
+  try {
+    // Fetch the latest news summary. Adjust maxResults if needed.
+    const { newsSummaries, noEventsFound } = await getNewsSummaries({ maxResults: 1 });
+
+    if (noEventsFound) {
+      // You can decide whether to return 404 or an empty array with 200
+      // For a "news" page, an empty result might be acceptable.
+      // If a summary is strictly expected, a 404 might be more appropriate.
+      // Let's go with 200 and an empty array for now.
+      res.status(200).json({ newsSummaries: [], noEventsFound: true });
+      return;
+    }
+
+    // Cache for 1 hour. Adjust as summaries are generated weekly.
+    // Once a new summary is generated, this cache should ideally be invalidated,
+    // or a shorter TTL used around the time of generation.
+    // For simplicity, a fixed TTL is used here.
+    // Vercel recommends: 'public, s-maxage=X, stale-while-revalidate=Y'
+    // s-maxage for CDN cache, max-age for browser cache (if not using s-maxage)
+    // For weekly news, could be s-maxage=604800 (1 week), stale-while-revalidate=3600 (1 hour)
+    // Let's use a more conservative 1-hour CDN cache for now.
+    res.setHeader('Cache-Control', 'public, s-maxage=3600, stale-while-revalidate=1800');
+    res.setHeader("Content-Type", "application/json");
+    res.status(200).json({ newsSummaries, noEventsFound: false });
+  } catch (error) {
+    console.error('Error in /api/news:', error);
+    // Sentry will capture this via withSentry wrapper
+    res.status(500).json({ error: "Failed to fetch news summaries" });
+  }
+}
+
+export default withSentry(handler);

--- a/pages/news.js
+++ b/pages/news.js
@@ -1,0 +1,50 @@
+// pages/news.js
+import React from 'react';
+import Head from 'next/head'; // Used by SeoMeta, but good to have for direct use if needed
+import BaseLayout from '../components/ui/layout/base'; // Adjusted path
+import SeoMeta from '../components/partials/seo-meta'; // Adjusted path
+import { useNewsSummary } from '../components/hooks/useNewsSummary'; // To be created
+
+export default function NewsPage() {
+  const { data, error, isLoading } = useNewsSummary(); // This hook will fetch from /api/news
+
+  if (isLoading) return <BaseLayout><div className="container mx-auto px-4 py-8"><p>Loading news...</p></div></BaseLayout>;
+  if (error) return <BaseLayout><div className="container mx-auto px-4 py-8"><p>Error loading news: {error.message}</p></div></BaseLayout>;
+
+  // Assuming data structure is { newsSummaries: [], noEventsFound: boolean }
+  const newsItem = data && data.newsSummaries && data.newsSummaries.length > 0
+    ? data.newsSummaries[0]
+    : null;
+
+  return (
+    <BaseLayout>
+      <SeoMeta
+        title="Weekly News - Cardedeu Cultural"
+        description="The latest cultural news and summaries for Cardedeu."
+      />
+      <div className="container mx-auto px-4 py-8">
+        <h1 className="text-3xl font-bold mb-6 text-center md:text-left">Notícies Culturals Setmanals</h1>
+        {newsItem ? (
+          <article className="prose lg:prose-xl max-w-none">
+            {/*
+              The newsItem comes from normalizeEvent.
+              The generateNewsSummary.js script puts the AI-generated "title" into the Google Calendar event's "summary" field.
+              And the AI-generated "summary paragraph" into the Google Calendar event's "description" field.
+              So, newsItem.summary should be the title, and newsItem.description the body.
+            */}
+            <h2 className="text-2xl font-semibold mt-4 mb-2">{newsItem.summary}</h2>
+            <div dangerouslySetInnerHTML={{ __html: newsItem.description }} />
+            {/*
+              If newsItem.description is guaranteed plain text (OpenAI prompt asked for plain text),
+              then <p>{newsItem.description}</p> would be safer.
+              However, calendar event descriptions can sometimes have basic HTML (like newlines as <br>).
+              Using dangerouslySetInnerHTML is fine if the source (our AI summary) is trusted.
+            */}
+          </article>
+        ) : (
+          <p className="text-center">No hi ha notícies disponibles actualment. Torna a intentar-ho més tard!</p>
+        )}
+      </div>
+    </BaseLayout>
+  );
+}

--- a/scripts/generateNewsSummary.js
+++ b/scripts/generateNewsSummary.js
@@ -1,0 +1,161 @@
+// scripts/generateNewsSummary.js
+const { google } = require('googleapis');
+const { OpenAIClient, AzureKeyCredential } = require("@azure/openai"); // Or use axios/fetch for REST
+const { week: getWeekDateRange } = require('../lib/dates'); // Assuming lib/dates.js can be used or adapted
+
+// --- Configuration ---
+const MAIN_CALENDAR_ID = '8e1jse11ireht56ho13r6a470s@group.calendar.google.com'; // Your main events calendar
+const NEWS_CALENDAR_ID = process.env.NEWS_CALENDAR_ID || 'YOUR_NEWS_CALENDAR_ID'; // The new calendar for news
+const AZURE_OPENAI_ENDPOINT = process.env.AZURE_OPENAI_ENDPOINT; // e.g., https://your-resource.openai.azure.com/
+const AZURE_OPENAI_API_KEY = process.env.AZURE_OPENAI_API_KEY;
+const OPENAI_DEPLOYMENT_NAME = process.env.AZURE_OPENAI_DEPLOYMENT_NAME || 'gpt-4o'; // Your GPT-4o deployment name
+
+// Authenticate with Google Calendar API for write access
+const auth = new google.auth.GoogleAuth({
+  scopes: ['https://www.googleapis.com/auth/calendar.events']
+  // GOOGLE_APPLICATION_CREDENTIALS environment variable should be set
+  // to the path of your service account key file.
+});
+const calendar = google.calendar({ version: 'v3', auth });
+
+// --- Helper Functions ---
+
+async function getUpcomingEvents() {
+  const { from, until } = getWeekDateRange(); // Get dates for the upcoming week
+
+  try {
+    const response = await calendar.events.list({
+      calendarId: MAIN_CALENDAR_ID,
+      timeMin: from.toISOString(),
+      timeMax: until.toISOString(),
+      singleEvents: true,
+      orderBy: 'startTime',
+      maxResults: 50, // Adjust as needed
+    });
+
+    if (!response.data.items) return [];
+    return response.data.items.map(event => ({
+      summary: event.summary,
+      description: event.description || '',
+      startDate: event.start.dateTime || event.start.date,
+      endDate: event.end.dateTime || event.end.date,
+      location: event.location || ''
+    }));
+  } catch (error) {
+    console.error('Error fetching upcoming events:', error);
+    throw error;
+  }
+}
+
+async function generateNewsSummaryOpenAI(events) {
+  if (!events || events.length === 0) {
+    return { title: "No events planned this week", summary: "Enjoy the quiet week!" };
+  }
+
+  const client = new OpenAIClient(AZURE_OPENAI_ENDPOINT, new AzureKeyCredential(AZURE_OPENAI_API_KEY));
+
+  const eventDetails = events.map(e =>
+    `- ${e.summary} (From: ${e.startDate} To: ${e.endDate}${e.location ? ', Location: ' + e.location : ''}${e.description ? '\n  Description: ' + e.description.substring(0,100) + '...' : ''})`
+  ).join('\n');
+
+  const messages = [
+    { role: "system", content: "You are an assistant that creates engaging weekly news summaries about events in Cardedeu. The summary should have a catchy title and a friendly tone." },
+    { role: "user", content: `Here are the events for next week in Cardedeu:\n${eventDetails}\n\nPlease generate a news summary post. The title should be something like 'The Best Plans in Cardedeu This Week' or 'What to do this weekend in Cardedeu'. The summary should highlight some of the most interesting events. Format the output as a JSON object with 'title' and 'summary' keys. The summary should be plain text, suitable for a blog post.` }
+  ];
+
+  try {
+    const result = await client.getChatCompletions(OPENAI_DEPLOYMENT_NAME, messages, {
+      maxTokens: 800, // Adjust as needed
+      temperature: 0.7,
+    });
+
+    if (result.choices && result.choices.length > 0) {
+      const content = result.choices[0].message.content;
+      // Attempt to parse the JSON from the content
+      try {
+        // The model might return the JSON string within triple backticks
+        const jsonMatch = content.match(/```json\n(.*\n)```/s);
+        const jsonString = jsonMatch ? jsonMatch[1].trim() : content.trim();
+        return JSON.parse(jsonString);
+      } catch (parseError) {
+        console.error("Error parsing OpenAI response JSON:", parseError, "Raw content:", content);
+        // Fallback if JSON parsing fails
+        return { title: "Weekly Summary for Cardedeu", summary: content };
+      }
+    } else {
+      throw new Error("OpenAI returned no choices.");
+    }
+  } catch (error) {
+    console.error('Error generating news summary with OpenAI:', error.response ? error.response.data : error.message);
+    throw error;
+  }
+}
+
+async function createNewsEvent(title, summaryContent) {
+  const { from: weekStart } = getWeekDateRange(); // Get start of the upcoming week
+  const eventStartTime = new Date(weekStart);
+  // Set to Monday 00:00:00 for an all-day event representation for the week's summary
+  eventStartTime.setHours(0, 0, 0, 0);
+
+  const event = {
+    summary: title,
+    description: summaryContent,
+    start: {
+      date: eventStartTime.toISOString().split('T')[0], // All-day event for the start of the week
+      timeZone: 'Europe/Madrid', // Or your specific timezone
+    },
+    end: {
+      date: eventStartTime.toISOString().split('T')[0], // All-day event, so end date is same as start
+      timeZone: 'Europe/Madrid',
+    },
+    // Optional: add a reminder or other properties
+    // Reminders can be useful if you want to be notified before it's "published"
+  };
+
+  try {
+    const createdEvent = await calendar.events.insert({
+      calendarId: NEWS_CALENDAR_ID,
+      resource: event,
+    });
+    console.log('News event created:', createdEvent.data.htmlLink);
+    return createdEvent.data;
+  } catch (error) {
+    console.error('Error creating news event:', error);
+    throw error;
+  }
+}
+
+// --- Main Execution ---
+async function main() {
+  if (!AZURE_OPENAI_ENDPOINT || !AZURE_OPENAI_API_KEY || !process.env.GOOGLE_APPLICATION_CREDENTIALS) {
+    console.error('Missing required environment variables: AZURE_OPENAI_ENDPOINT, AZURE_OPENAI_API_KEY, GOOGLE_APPLICATION_CREDENTIALS, and possibly NEWS_CALENDAR_ID.');
+    process.exit(1);
+  }
+
+  try {
+    console.log('Fetching upcoming events...');
+    const upcomingEvents = await getUpcomingEvents();
+    console.log(`Found ${upcomingEvents.length} events.`);
+
+    if (upcomingEvents.length === 0) {
+      console.log("No upcoming events to summarize. Skipping news generation.");
+      // Optionally, still create a "no events" post if desired
+      // await createNewsEvent("No Events This Week in Cardedeu", "It looks like a quiet week in Cardedeu. Check back next week for more updates!");
+      return;
+    }
+
+    console.log('Generating news summary with OpenAI...');
+    const { title, summary } = await generateNewsSummaryOpenAI(upcomingEvents);
+    console.log(`Generated summary - Title: ${title}`);
+
+    console.log('Creating news event in Google Calendar...');
+    await createNewsEvent(title, summary);
+
+    console.log('Successfully generated and stored news summary.');
+  } catch (error) {
+    console.error('Failed to generate weekly news summary:', error);
+    process.exit(1);
+  }
+}
+
+main();


### PR DESCRIPTION
This commit introduces a new feature to generate and display weekly cultural news summaries.

Key changes include:

-   **News Generation Script (`scripts/generateNewsSummary.js`):**
    -   Fetches upcoming events from the main Google Calendar.
    -   Uses OpenAI (GPT-4o via Azure) to generate a title and summary for these events.
    -   Creates a new event in a dedicated "News" Google Calendar to store this summary.
    -   Requires environment variables for Azure OpenAI credentials, Google Calendar IDs, and Google Service Account credentials for write access.

-   **News API Endpoint (`pages/api/news.js`):**
    -   Exposes an endpoint to fetch the latest news summary.
    -   Uses the `getNewsSummaries` helper.
    -   Includes caching and Sentry integration.

-   **News Page (`pages/news.js`):**
    -   New page at `/news` to display the weekly summary.
    -   Uses the `useNewsSummary` hook for data fetching.
    -   Includes basic loading, error handling, and display of the news title and content.

-   **Helper Functions & Hooks:**
    -   `lib/helpers.js`: Added `getNewsSummaries` to fetch news items from the designated Google Calendar.
    -   `components/hooks/useNewsSummary.js`: New SWR hook for the `/news` page.

-   **Testing:**
    -   Added Jest unit tests for the `/api/news` endpoint (`__tests__/pages/api/news.test.js`).
    -   Added Jest unit tests for the `getNewsSummaries` function (`__tests__/lib/helpers.test.js`).

-   **Configuration & Documentation (Guidance Provided):**
    -   Outlined necessary environment variables.
    -   Suggested methods for scheduling the weekly execution of the generation script (GitHub Actions, Vercel Cron, etc.).

This feature allows your site to provide users with AI-generated weekly highlights of cultural events in Cardedeu.