### PR TITLE
refactor(ai): route summaries through the hosted ai-gateway

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The site automatically generates weekly cultural news summaries using AI:
 ### How it works:
 
 1. **Data Collection**: Fetches upcoming events from Google Calendar
-2. **AI Generation**: Uses the [ai-gateway](https://github.com/albertolive/ai-gateway) provider cascade (`lib/gatewayClient.js`) to create engaging summaries in Catalan
+2. **AI Generation**: Uses the hosted [ai-gateway](https://github.com/albertolive/ai-gateway) (`lib/gatewayClient.js`) — one `GATEWAY_TOKEN`, cascade-first — to create engaging summaries in Catalan
 3. **Storage**: Saves summaries as events in a separate Google Calendar
 4. **Display**: Shows summaries on `/noticies` page with individual article pages
 
@@ -27,12 +27,10 @@ The site automatically generates weekly cultural news summaries using AI:
 #### 1. Environment Variables
 
 ```bash
-# ai-gateway providers (for AI generation, /api/generateNewsSummary and /api/generatemeteo)
-OPENROUTER_API_KEY=your_openrouter_api_key
-GEMINI_API_KEY=your_gemini_api_key
-GROQ_API_KEY=your_groq_api_key
+# Hosted ai-gateway (for AI generation, /api/generateNewsSummary and /api/generatemeteo)
+GATEWAY_TOKEN=your_gateway_token
 
-# GEMINI_API_KEY above is also used directly by /api/analyzeImage (Gemini's
+# GEMINI_API_KEY is used directly by /api/analyzeImage (Gemini's
 # OpenAI-compatible endpoint, called for vision support)
 
 # Google Calendar API
@@ -55,7 +53,8 @@ GOOGLE_APPLICATION_CREDENTIALS=/path/to/service-account-key.json
 
 Add these secrets to your GitHub repository:
 
-- `OPENROUTER_API_KEY`, `GEMINI_API_KEY`, `GROQ_API_KEY`: ai-gateway provider keys (`GEMINI_API_KEY` also powers `/api/analyzeImage`)
+- `GATEWAY_TOKEN`: hosted ai-gateway key (powers `/api/generateNewsSummary` and `/api/generatemeteo`)
+- `GEMINI_API_KEY`: powers `/api/analyzeImage` (vision)
 - `NEWS_CALENDAR_ID`: Your news calendar ID
 - `GOOGLE_SERVICE_ACCOUNT_KEY`: Contents of your service account JSON file
 
@@ -109,7 +108,7 @@ Deployed on Vercel with automatic deployments from the main branch.
 - Tailwind CSS
 - SWR for data fetching
 - Google Calendar API
-- ai-gateway provider cascade (news summaries) / Gemini 2.0 Flash (image analysis)
+- hosted ai-gateway (news summaries) / Gemini Flash (image analysis)
 - Sentry for error tracking
 
 ## Getting Started

--- a/lib/gatewayClient.js
+++ b/lib/gatewayClient.js
@@ -1,81 +1,50 @@
-// Vendored ai-gateway client for application runtime code (not CI).
+// Hosted ai-gateway client for application runtime code (not CI).
 //
-// Copy this single file into your app. It fetches the shared provider/model
-// config from ai-gateway's models.json on each call, so swapping a model or
-// adding a provider (e.g. a paid one like DeepSeek) is a one-line edit in
-// ai-gateway -- this file and your app code never change. If the fetch fails
-// (GitHub outage), it falls back to OpenRouter's free auto-router so the app
-// doesn't hard-fail on a transient network issue.
+// Points at the shared ai-gateway endpoint (albertolive/ai-gateway), which
+// resolves a cascade name to a provider/model/key and fails over across the
+// whole cascade server-side. This repo holds ONE key (GATEWAY_TOKEN) and sends
+// a cascade name — never a provider, model id, or provider API key — so a
+// model swap or deprecation is a one-line edit in ai-gateway, not here.
 //
 // Usage:
 //   import { complete } from "@lib/gatewayClient";
 //   const text = await complete("Summarize this weather forecast: ...");
-//   const text = await complete("...", { cascade: "deepseek_cheap" }); // paid, needs DEEPSEEK_API_KEY
+//   const text = await complete("...", { cascade: "frontier" }); // paid, opt-in
 //
-// Env: one API key per provider you use (OPENROUTER_API_KEY, DEEPSEEK_API_KEY,
-//      GEMINI_API_KEY, GROQ_API_KEY). Only providers with a key set are tried.
+// Env: GATEWAY_TOKEN (required). Optional: AI_GATEWAY_URL to override the
+//      endpoint (defaults to the hosted ai-gateway).
+//
+// Note: vision is NOT served by the gateway yet — /api/analyzeImage calls
+// Gemini directly for that, and is the one documented exception.
 
-const CONFIG_URL =
-  "https://raw.githubusercontent.com/albertolive/ai-gateway/main/models.json";
-
-const FALLBACK_PROVIDERS = {
-  openrouter: { url: "https://openrouter.ai/api/v1", key_env: "OPENROUTER_API_KEY" },
-};
-const FALLBACK_ENTRIES = [{ provider: "openrouter", model: "openrouter/free" }];
-
-async function loadConfig(timeoutMs = 10000) {
-  try {
-    const res = await fetch(CONFIG_URL, { signal: AbortSignal.timeout(timeoutMs) });
-    return await res.json();
-  } catch {
-    return { providers: FALLBACK_PROVIDERS, cascades: {} };
-  }
-}
+const GATEWAY_URL =
+  process.env.AI_GATEWAY_URL ||
+  "https://ai-gateway-livid-eight.vercel.app/api/chat/completions";
 
 export async function complete(prompt, { cascade = "general", system, temperature = 0.1 } = {}) {
-  const config = await loadConfig();
-  const providers = Object.keys(config.providers || {}).length
-    ? config.providers
-    : FALLBACK_PROVIDERS;
-  const entries = (config.cascades && config.cascades[cascade]) || FALLBACK_ENTRIES;
-
-  const errors = [];
-  for (const entry of entries) {
-    const provider = providers[entry.provider];
-    if (!provider) {
-      errors.push(`${entry.provider}/${entry.model}: unknown provider '${entry.provider}'`);
-      continue;
-    }
-    const apiKey = process.env[provider.key_env];
-    if (!apiKey) {
-      errors.push(`${entry.provider}/${entry.model}: ${provider.key_env} not set`);
-      continue;
-    }
-
-    const messages = [
-      ...(system ? [{ role: "system", content: system }] : []),
-      { role: "user", content: prompt },
-    ];
-
-    try {
-      const res = await fetch(`${provider.url.replace(/\/$/, "")}/chat/completions`, {
-        method: "POST",
-        headers: {
-          Authorization: `Bearer ${apiKey}`,
-          "Content-Type": "application/json",
-        },
-        body: JSON.stringify({ model: entry.model, messages, temperature }),
-      });
-      if (!res.ok) throw new Error(`HTTP ${res.status}: ${await res.text()}`);
-      const body = await res.json();
-      return body.choices[0].message.content;
-    } catch (e) {
-      errors.push(`${entry.provider}/${entry.model}: ${e}`);
-    }
+  const token = process.env.GATEWAY_TOKEN;
+  if (!token) {
+    throw new Error("GATEWAY_TOKEN not set");
   }
 
-  throw new Error(
-    `All providers in cascade '${cascade}' failed or were unconfigured:\n` +
-      errors.map((e) => `  - ${e}`).join("\n")
-  );
+  const messages = [
+    ...(system ? [{ role: "system", content: system }] : []),
+    { role: "user", content: prompt },
+  ];
+
+  const res = await fetch(GATEWAY_URL, {
+    method: "POST",
+    headers: {
+      Authorization: `Bearer ${token}`,
+      "Content-Type": "application/json",
+    },
+    body: JSON.stringify({ model: cascade, messages, temperature }),
+  });
+
+  if (!res.ok) {
+    throw new Error(`ai-gateway HTTP ${res.status}: ${await res.text()}`);
+  }
+
+  const body = await res.json();
+  return body.choices?.[0]?.message?.content ?? null;
 }


### PR DESCRIPTION
## What

Route AI news/meteo summary generation through the hosted ai-gateway instead of the per-repo provider keys + `models.json` fetch.

- **`lib/gatewayClient.js`** — rewritten to POST a cascade name (`general`) to the hosted ai-gateway endpoint with a single `GATEWAY_TOKEN`. No more `models.json` fetch or per-provider keys.
- **`README.md`** — env var docs updated (`GATEWAY_TOKEN` for summaries, `GEMINI_API_KEY` only for image analysis).
- **`pages/api/generateNewsSummary.js` / `generatemeteo.js`** — unchanged (already passed `cascade: "general"`).

## Why

Model swaps, deprecations, and multi-account failover now live in one place (ai-gateway), so a model change reaches this repo's next run with zero code changes here.

## The one exception

`/api/analyzeImage` stays direct-Gemini: it sends image input (vision), which the hosted gateway does not serve yet. This is the documented multimodal exception.

## Verification

- `node --check lib/gatewayClient.js` clean.
- Smoke-tested `complete("Say OK", { cascade: "general" })` against the live gateway → `200`, returned `"OK"`.
- No remaining `OPENROUTER_API_KEY`/`GROQ_API_KEY`/`DEEPSEEK_API_KEY` references outside the PR-review workflow.

## Note

Requires `GATEWAY_TOKEN` set on this repo's Vercel project before the next run (its value lives in `ai-gateway/.env.gateway`). `GEMINI_API_KEY` must stay set for `/api/analyzeImage`.


<!-- This is an auto-generated description by cubic. -->
---
## Summary by cubic
Routes AI news and meteo summaries through the hosted `ai-gateway` with a single `GATEWAY_TOKEN`, replacing the per-provider keys and `models.json` fetch. This centralizes model selection and failover in the gateway; image analysis remains direct Gemini.

- Rewrites `lib/gatewayClient.js` to POST a cascade name (default `general`) to the hosted endpoint, with optional `AI_GATEWAY_URL` override. Returns the first choice’s content and throws on non-2xx (`ai-gateway HTTP ...`).
- Removes use of `OPENROUTER_API_KEY`, `GROQ_API_KEY`, and `DEEPSEEK_API_KEY` for summaries; only `GATEWAY_TOKEN` is required.
- Updates `README.md` env docs; `/api/analyzeImage` still uses `GEMINI_API_KEY` (vision). Summary API routes were already sending `cascade: "general"`.

**Rollout**
- Set `GATEWAY_TOKEN` in Vercel before the next run. Required.
- Keep `GEMINI_API_KEY` for `/api/analyzeImage`.
- Optionally remove unused provider keys from secrets.
- Optional: set `AI_GATEWAY_URL` if self-hosting the gateway.

<sup>Written for commit b7ebf12ba16416948483e7920bdba43d4c227108. Summary will update on new commits.</sup>

<a href="https://cubic.dev/pr/albertolive/culturaCardedeu/pull/212?utm_source=github" target="_blank" rel="noopener noreferrer" data-no-image-dialog="true"><picture><source media="(prefers-color-scheme: dark)" srcset="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://www.cubic.dev/buttons/review-in-cubic-light.svg"><img alt="Review in cubic" src="https://www.cubic.dev/buttons/review-in-cubic-dark.svg"></picture></a>

<!-- End of auto-generated description by cubic. -->



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added hosted AI gateway support for news generation using a single gateway token.
  * Added optional gateway endpoint configuration.
  * Added support for system prompts and response temperature settings.

* **Documentation**
  * Updated setup and GitHub Actions instructions for gateway and image-analysis credentials.
  * Updated the technology listing to reference the hosted gateway and Gemini Flash.

* **Bug Fixes**
  * Improved error handling for missing credentials and unsuccessful gateway responses.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->